### PR TITLE
Fix typo in include guard

### DIFF
--- a/NTPClient.h
+++ b/NTPClient.h
@@ -1,4 +1,4 @@
-#ifndef NTPClIENT_H
+#ifndef NTPCLIENT_H
 #define NTPCLIENT_H
 
 #include <string>


### PR DESCRIPTION
Include guard had a typo